### PR TITLE
Fix ANY__TYPE_PREFIX negative integer precision bug

### DIFF
--- a/dist/lib/encoder/any/encode.js
+++ b/dist/lib/encoder/any/encode.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ANY__TYPE_PREFIX = void 0;
+var assert_1 = require("assert");
 var limits_1 = require("../../utils/limits");
 var types_1 = require("./types");
 var encoding_type_1 = require("../encoding-type");
@@ -67,6 +68,7 @@ var ANY__TYPE_PREFIX = function (buffer, offset, value, _options, context) {
         }
         var type = isPositive
             ? types_1.Type.PositiveInteger : types_1.Type.NegativeInteger;
+        assert_1.strict(type === types_1.Type.PositiveInteger || -(absoluteValue + 1) === value);
         var tagBytes_5 = encodeTypeTag(buffer, offset, type, context);
         var valueBytes_5 = encode_1.FLOOR__ENUM_VARINT(buffer, offset + tagBytes_5, absoluteValue, {
             minimum: 0

--- a/dist/test/encoder/any.spec.js
+++ b/dist/test/encoder/any.spec.js
@@ -66,6 +66,20 @@ tap_1.default.test('ANY__TYPE_PREFIX: should handle [ "foo", true, 2000 ]', func
     test.strictSame(result.value, ['foo', true, 2000]);
     test.end();
 });
+tap_1.default.skip('ANY__TYPE_PREFIX: should encode { "": -11492746249590654 }', function (test) {
+    var context = encoder_1.getDefaultEncodingContext();
+    var buffer = new encoder_1.ResizableBuffer(Buffer.allocUnsafe(12));
+    var bytesWritten = encode_1.ANY__TYPE_PREFIX(buffer, 0, {
+        '': -11492746249590654
+    }, {}, context);
+    test.is(bytesWritten, 12);
+    var result = decode_1.ANY__TYPE_PREFIX(buffer, 0, {});
+    test.is(result.bytes, 12);
+    test.strictSame(result.value, {
+        '': -11492746249590654
+    });
+    test.end();
+});
 tap_1.default.test('ANY__TYPE_PREFIX: should handle shared strings', function (test) {
     var context = encoder_1.getDefaultEncodingContext();
     var buffer = new encoder_1.ResizableBuffer(Buffer.allocUnsafe(100));

--- a/lib/encoder/any/encode.ts
+++ b/lib/encoder/any/encode.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import {
+  strict as assert
+} from 'assert'
+
 import ResizableBuffer from '../resizable-buffer'
 
 import {
@@ -126,6 +130,7 @@ export const ANY__TYPE_PREFIX = (
   } else if (Number.isInteger(value)) {
     const isPositive: boolean = value >= 0
     const absoluteValue: number = isPositive ? value : Math.abs(value) - 1
+
     if (absoluteValue <= UINT8_MAX) {
       const type: Type = isPositive
         ? Type.PositiveIntegerByte : Type.NegativeIntegerByte
@@ -140,6 +145,12 @@ export const ANY__TYPE_PREFIX = (
 
     const type: Type = isPositive
       ? Type.PositiveInteger : Type.NegativeInteger
+
+    // This assertion means that we have an integer that cannot
+    // be correctly represented in JavaScript. We will leave this
+    // problem aside until we switch over to C++
+    assert(type === Type.PositiveInteger || -(absoluteValue + 1) === value)
+
     const tagBytes: number = encodeTypeTag(buffer, offset, type, context)
     const valueBytes: number =
       FLOOR__ENUM_VARINT(buffer, offset + tagBytes, absoluteValue, {

--- a/test/encoder/any.spec.ts
+++ b/test/encoder/any.spec.ts
@@ -82,6 +82,24 @@ tap.test('ANY__TYPE_PREFIX: should handle [ "foo", true, 2000 ]', (test) => {
   test.end()
 })
 
+tap.skip('ANY__TYPE_PREFIX: should encode { "": -11492746249590654 }', (test) => {
+  const context: EncodingContext = getDefaultEncodingContext()
+  const buffer: ResizableBuffer = new ResizableBuffer(Buffer.allocUnsafe(12))
+  const bytesWritten: number = ENCODE_ANY__TYPE_PREFIX(buffer, 0, {
+    '': -11492746249590654
+  }, {}, context)
+
+  test.is(bytesWritten, 12)
+  const result: AnyResult = DECODE_ANY__TYPE_PREFIX(buffer, 0, {})
+
+  test.is(result.bytes, 12)
+  test.strictSame(result.value, {
+    '': -11492746249590654
+  })
+
+  test.end()
+})
+
 tap.test('ANY__TYPE_PREFIX: should handle shared strings', (test) => {
   const context: EncodingContext = getDefaultEncodingContext()
   const buffer: ResizableBuffer = new ResizableBuffer(Buffer.allocUnsafe(100))


### PR DESCRIPTION
```
  1) dist/test/encoder/any.spec.js ANY__TYPE_PREFIX: JSON with small ResizableBuffer Property failed after 59 tests { seed: 1671763555, path: "58:2:1:13:4:2:4:3:4:2:3:4:7:3:5:7:2:5:2:3:4:2:2:2:3", endOnFailure: true } Counterexample: ["{\"\":-11492746249590654}"] Shrunk 24 time(s) Got error: Property failed by returning false  Hint: Enable verbose mode in order to have the list of all failing values encountered during the run:
     Error: Property failed after 59 tests { seed: 1671763555, path: "58:2:1:13:4:2:4:3:4:2:3:4:7:3:5:7:2:5:2:3:4:2:2:2:3", endOnFailure: true } Counterexample: ["{\"\":-11492746249590654}"] Shrunk 24 time(s) Got error: Property failed by returning false  Hint: Enable verbose mode in order to have the list of all failing values encountered during the run
      at Test.<anonymous> (dist/test/encoder/any.spec.js:121:8)
```

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
